### PR TITLE
Issue #73: Changed `dateFormat` to "%B %d, %Y": it'll produce date days with leading zeros ("March 01, 2024").

### DIFF
--- a/dds_registration/core/constants/date_time_formats.py
+++ b/dds_registration/core/constants/date_time_formats.py
@@ -2,7 +2,7 @@
 
 # @see https://www.geeksforgeeks.org/python-strftime-function/
 dateTimeFormat = "%Y.%m.%d %H:%M %Z"
-dateFormat = "%B %#d, %Y"  # TODO: A day without zero? NOTE: It seems to be non-cross-platform: '%#d' is for windows and '%-d' -- for unix
+dateFormat = "%B %d, %Y"  # TODO: A day without zero? NOTE: It seems to be non-cross-platform: '%#d' is for windows and '%-d' -- for unix
 #  dateFormat = '%Y.%m.%d'
 dateTagFormat = "%y%m%d-%H%M"  # eg: '220208-0204'
 dateTagPreciseFormat = "%y%m%d-%H%M%S"  # eg: '220208-020423'


### PR DESCRIPTION
TODO: To find a cross-platform solution for this problem.