### PR TITLE
Issue #115: Added unpaid membership invoice section (in a form of standard warning box) into the profile page.

### DIFF
--- a/dds_registration/templates/dds_registration/profile.html.django
+++ b/dds_registration/templates/dds_registration/profile.html.django
@@ -52,6 +52,14 @@
   <p>Not yet a DdS member. <a href="{% url 'membership_application' %}">Apply for membership</a>.</p>
 {% endif %}
 
+{% if user.membership.payment.status == 'ISSUED' %}
+  <p class="alert alert-warning" role="alert">
+  <strong>You have unpaid membership invoice.</strong>
+    Your membership isn't valid yet.
+    You can <a target="_blank" href="{% url 'invoice_download' payment_id=user.membership.payment.id %}">download an ivoice</a> to pay for it now.
+  </p>
+{% endif %}
+
 <div>
   {# TODO: Put common actions toolbar here #}
   <a class="btn btn-primary" href="{% url 'profile_edit' %}">Edit profile</a>

--- a/dds_registration/templates/dds_registration/profile.html.django
+++ b/dds_registration/templates/dds_registration/profile.html.django
@@ -44,21 +44,25 @@
 
 <h3 class="primary-color">Membership:</h3>
 
-{% if user.is_member %}
 {% with membership=user.membership %}
+
+{% if user.is_member %}
   <p>Member since {{ membership.started }}. Membership type: {{ membership.get_membership_type_display }}.</p>
-{% endwith %}
 {% else %}
   <p>Not yet a DdS member. <a href="{% url 'membership_application' %}">Apply for membership</a>.</p>
 {% endif %}
 
-{% if user.membership.payment.status == 'ISSUED' %}
-  <p class="alert alert-warning" role="alert">
-  <strong>You have unpaid membership invoice.</strong>
-    Your membership isn't valid yet.
-    You can <a target="_blank" href="{% url 'invoice_download' payment_id=user.membership.payment.id %}">download an ivoice</a> to pay for it now.
-  </p>
-{% endif %}
+{% with payment=membership.payment %}
+  {% if payment and payment.status == 'ISSUED' %}
+    <p class="alert alert-warning" role="alert">
+    <strong>You have unpaid membership invoice.</strong>
+      Your membership isn't valid yet.
+      You can <a target="_blank" href="{% url 'invoice_download' payment_id=user.membership.payment.id %}">download an invoice</a> to pay for it now.
+    </p>
+  {% endif %}
+{% endwith %}
+
+{% endwith %}
 
 <div>
   {# TODO: Put common actions toolbar here #}

--- a/dds_registration/views/payment_utils.py
+++ b/dds_registration/views/payment_utils.py
@@ -16,7 +16,7 @@ def invoice_download(request: HttpRequest, payment_id: int) -> HttpResponse:
         raise PermissionDenied()
 
     response = HttpResponse(content=bytes(payment.invoice_pdf().output()), content_type="application/pdf")
-    response["Content-Disposition"] = f'inline; filename="DdS invoice {payment.invoice_no}.pdf"'
+    response["Content-Disposition"] = f'attachment; filename="DdS invoice {payment.invoice_no}.pdf"'
     return response
 
 
@@ -31,5 +31,5 @@ def receipt_download(request: HttpRequest, payment_id: int) -> HttpResponse:
         raise PermissionDenied()
 
     response = HttpResponse(content=bytes(payment.receipt_pdf().output()), content_type="application/pdf")
-    response["Content-Disposition"] = f'inline; filename="DdS receipt {payment.invoice_no}.pdf"'
+    response["Content-Disposition"] = f'attachment; filename="DdS receipt {payment.invoice_no}.pdf"'
     return response

--- a/dds_registration/views/payment_utils.py
+++ b/dds_registration/views/payment_utils.py
@@ -16,7 +16,7 @@ def invoice_download(request: HttpRequest, payment_id: int) -> HttpResponse:
         raise PermissionDenied()
 
     response = HttpResponse(content=bytes(payment.invoice_pdf().output()), content_type="application/pdf")
-    response["Content-Disposition"] = f'attachment; filename="DdS invoice {payment.invoice_no}.pdf"'
+    response["Content-Disposition"] = f'inline; filename="DdS invoice {payment.invoice_no}.pdf"'
     return response
 
 
@@ -31,5 +31,5 @@ def receipt_download(request: HttpRequest, payment_id: int) -> HttpResponse:
         raise PermissionDenied()
 
     response = HttpResponse(content=bytes(payment.receipt_pdf().output()), content_type="application/pdf")
-    response["Content-Disposition"] = f'attachment; filename="DdS receipt {payment.invoice_no}.pdf"'
+    response["Content-Disposition"] = f'inline; filename="DdS receipt {payment.invoice_no}.pdf"'
     return response


### PR DESCRIPTION
Changed `Content-Disposition` header for generated pdf invoices to 'inline' to allow them to be opened in a browser tabs.

Added unpaid membership invoice section into the profile page.

![2024-04-08-16-19-41](https://github.com/Depart-de-Sentier/dds_registration/assets/6855837/405dd4c0-ab35-4993-adf4-4662adff4196)
