### PR TITLE
Add CAPTCHA field to registration form

### DIFF
--- a/dds_registration/apps.py
+++ b/dds_registration/apps.py
@@ -14,4 +14,6 @@ class RegConfig(AppConfig):
             stripe.api_key = settings.STRIPE_SECRET_KEY
 
         SURVEY_FIELD_VALIDATORS["min_length"]["text_area"] = 3
-        SURVEY_FIELD_VALIDATORS["max_length"] = {"email": 250, "text": 2500, "url": 500}
+        SURVEY_FIELD_VALIDATORS["max_length"].update(
+            email=250, text=2500, url=500,
+        )

--- a/dds_registration/forms.py
+++ b/dds_registration/forms.py
@@ -1,3 +1,4 @@
+from captcha.fields import CaptchaField
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
@@ -100,6 +101,7 @@ class DdsRegistrationForm(BaseRegistrationForm):
         required=False,
         widget=forms.Textarea(attrs={"class": "form-control", "rows": 5}),
     )
+    captcha = CaptchaField()
 
     class Meta:
         model = User

--- a/dds_registration/settings.py
+++ b/dds_registration/settings.py
@@ -134,6 +134,7 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.staticfiles",
     "compressor",
+    "captcha",
     "crispy_forms",
     "crispy_bootstrap5",
     "django_registration",

--- a/dds_registration/urls/root_urls.py
+++ b/dds_registration/urls/root_urls.py
@@ -14,6 +14,7 @@ cache_timeout = 0 if settings.DEV or settings.DEBUG else 15 * 60  # in seconds: 
 urlpatterns = [
     # App-provided paths...
     path("admin/", admin.site.urls, name="admin"),
+    path("captcha/", include("captcha.urls")),
     path("hijack/", include("hijack.urls")),
     path("applications/", include((application_urlpatterns, "djf_surveys"))),
     # Service pages...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "django-preferences>=1.0.0",
     "django-prettyjson",
     "django-registration==3.4", # @see https://django-registration.readthedocs.io
+    "django-simple-captcha>=0.6.2",
     "django-timezone-field>=3.1",
     "django>=5.0",
     "fpdf2>=2.7.8", # @see https://github.com/py-pdf/fpdf2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+    "pyyaml",
+
     "beautifulsoup4>=4.12.3",  # Html content prettifier
     "crispy-bootstrap5>=2024.2",
     "django-compressor>=4.4",


### PR DESCRIPTION
Use [`django-simple-captcha`](https://github.com/mbi/django-simple-captcha.git) to add a CAPTCHA field to the user registration form.

<details>
    <summary>example</summary>
    <img width="1024" height="1104" alt="2025-08-20-103839_1920x2160_scrot" src="https://github.com/user-attachments/assets/38fce530-df90-4058-a0c4-fc4ecf2bfb9c" />
</details>

---

The following operating system packages [need](https://django-simple-captcha.readthedocs.io/en/latest/usage.html#installation) to be installed on the server before these changes are applied:

```
apt-get -y install libz-dev libjpeg-dev libfreetype6-dev python-dev
```